### PR TITLE
Allow shake-0.14

### DIFF
--- a/avr-shake.cabal
+++ b/avr-shake.cabal
@@ -27,4 +27,4 @@ Library
                         dependent-sum,
                         mtl,
                         process,
-                        shake >= 0.10 && < 0.14
+                        shake >= 0.10 && < 0.15


### PR DESCRIPTION
avr-shake compiles fine with shake-0.14 so relaxing the upper bound. Going forward, I generally encourage removing upper bounds entirely, but appreciate that's a personal choice ([my thoughts are here](http://neilmitchell.blogspot.co.uk/2014/11/upper-bounds-or-not.html)).
